### PR TITLE
Patch/long range kgun background fix

### DIFF
--- a/src/lib/genHex.ts
+++ b/src/lib/genHex.ts
@@ -75,14 +75,14 @@ const genSvg = (id: string, lines: IPoint[][], path: string | undefined = undefi
             const pt = arcpt(size / 2, size / 2, rOuter, deg2rad(deg));
             pointsOuter.push(`${pt.x},${pt.y}`);
         }
-        s += `<polygon points="${pointsOuter.join(" ")}" fill="white"  fill-opacity="0" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`
+        s += `<polygon id="outer" points="${pointsOuter.join(" ")}" fill="white"  fill-opacity="0" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`
     }
     const pointsInner: string[] = [];
     for (const deg of [60, 120, 180, 240, 300, 360]) {
         const pt = arcpt(size / 2, size / 2, rInner, deg2rad(deg));
         pointsInner.push(`${pt.x},${pt.y}`);
     }
-    s += `<polygon points="${pointsInner.join(" ")}" fill="white" fill-opacity="0" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`
+    s += `<polygon points="${pointsInner.join(" ")}" id="inner" fill="white" fill-opacity="0" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`
     for (const line of lines) {
         s += `<line x1="${line[0].x}" y1="${line[0].y}" x2="${line[1].x}" y2="${line[1].y}" stroke-width="20" stroke-miterlimit="10" stroke="black" />`;
     }

--- a/src/lib/systems/kgun.ts
+++ b/src/lib/systems/kgun.ts
@@ -128,7 +128,7 @@ export class Kgun extends System {
         let svg = genHex(id, this.numArcs, this.leftArc, undefined, insert);
         // If long range, fill the centre hex
         if (this.modifier === "long") {
-            svg = svg.replace(`<polygon points="403.05,478.4878357199728 196.95000000000005,478.48783571997285 93.9,300 196.94999999999993,121.51216428002724 403.05,121.5121642800272 506.1,299.99999999999994" fill="white" fill-opacity="0" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`, `<polygon points="403.05,478.4878357199728 196.95000000000005,478.48783571997285 93.9,300 196.94999999999993,121.51216428002724 403.05,121.5121642800272 506.1,299.99999999999994" fill="black" fill-opacity="1" stroke="#000000" stroke-width="20" stroke-miterlimit="10"/>`);
+            svg = svg.replace(`id="inner" fill="white" fill-opacity="0"`, `id="inner" fill="black" fill-opacity="1"`);
         // If short range, change the viewbox
         } else if (this.modifier === "short") {
             svg = svg.replace(`viewBox="-1 -1 602 602"`, `viewBox="-26 24 652 652"`);


### PR DESCRIPTION
Fixes issue with Long Range K-Gun Glyph Background being white instead of black.

The .replace() match string was failing to match the desired section of the SVG content resulting in a failed replace. 

Issue resolved by adding an id prop to the SVG <polygon> tag and reducing the match target size to only match the 3 target properties instead of the whole <polygon> tag.